### PR TITLE
Fix installing torch points kernels with latest pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Unreleased
 
+# 0.5.3
+
+## Update
 - ball query returns squared distance instead of distance
 - leaner Point Cloud struct that avoids copying data
+
+## Bug fix
+- Pcakage would not install if pytorch is not already installed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include README.md
 include LICENSE
+include CHANGELOG.md
+include pyproject.toml
 
 recursive-exclude test *
 recursive-include cpu *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,5 @@ exclude = '''
 '''
 
 [build-system]
-requires = ["setuptools>=41.0", "setuptools-scm", "wheel"]
+requires = ["setuptools>=41.0", "setuptools-scm", "wheel", "torch"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 TORCH_MAJOR = int(torch.__version__.split(".")[0])
 TORCH_MINOR = int(torch.__version__.split(".")[1])
-extra_compile_args = ["-03"]
+extra_compile_args = ["-O3"]
 if (TORCH_MAJOR > 1) or (TORCH_MAJOR == 1 and TORCH_MINOR > 2):
     extra_compile_args += ["-DVERSION_GE_1_3"]
 

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,9 @@ setup(
     ext_modules=ext_modules,
     cmdclass={"build_ext": BuildExtension},
     long_description=long_description,
-    long_description_content_type='text/markdown'
+    long_description_content_type='text/markdown',
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 TORCH_MAJOR = int(torch.__version__.split(".")[0])
 TORCH_MINOR = int(torch.__version__.split(".")[1])
-extra_compile_args = []
+extra_compile_args = ["-03"]
 if (TORCH_MAJOR > 1) or (TORCH_MAJOR == 1 and TORCH_MINOR > 2):
     extra_compile_args += ["-DVERSION_GE_1_3"]
 
@@ -48,7 +48,7 @@ ext_modules.append(
 requirements = ["torch>=1.1.0"]
 
 url = 'https://github.com/nicolas-chaulet/torch-points-kernels'
-__version__="0.5.2"
+__version__="0.5.3"
 setup(
     name="torch-points-kernels",
     version=__version__,


### PR DESCRIPTION
Fixes errors when someone tries to install the package without pytorch already installed