### PR TITLE
Better type checks, allows float16 and more

### DIFF
--- a/cuda/include/utils.h
+++ b/cuda/include/utils.h
@@ -17,11 +17,11 @@
 #define CHECK_IS_INT(x)                                                                            \
     do                                                                                             \
     {                                                                                              \
-        TORCH_CHECK(x.scalar_type() == at::ScalarType::Int, #x " must be an int tensor");          \
+        TORCH_CHECK(isIntegralType(x.scalar_type(), false), #x " must be an int tensor");          \
     } while (0)
 
 #define CHECK_IS_FLOAT(x)                                                                          \
     do                                                                                             \
     {                                                                                              \
-        TORCH_CHECK(x.scalar_type() == at::ScalarType::Float, #x " must be a float tensor");       \
+        TORCH_CHECK(isFloatingType(x.scalar_type()), #x " must be a float tensor");       \
     } while (0)


### PR DESCRIPTION
This fixes type checks so that float16, bfloat16 and float64 are also considered floats.
The same is done for integers.

This allows us for example to pass FP16 tensors to three_nn, three_interpolate, ball_query, furthest_point_sampling (this is needed in a Mixed Precision setup)


The int change only affects three_interpolate.


https://github.com/pytorch/pytorch/blob/master/c10/core/ScalarType.h#L216-L228

@nicolas-chaulet 