### PR TITLE
Add support for Half dtype and mixed precision training.

### DIFF
--- a/cuda/include/ball_query.h
+++ b/cuda/include/ball_query.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <torch/extension.h>
 
-std::pair<at::Tensor, at::Tensor> ball_query_dense(at::Tensor new_xyz, at::Tensor xyz,
-                                                   const float radius, const int nsample);
+std::pair<torch::Tensor, torch::Tensor> ball_query_dense(torch::Tensor new_xyz, torch::Tensor xyz,
+                                                         const float radius, const int nsample);
 
-std::pair<at::Tensor, at::Tensor> ball_query_partial_dense(at::Tensor x, at::Tensor y,
-                                                           at::Tensor batch_x, at::Tensor batch_y,
-                                                           const float radius, const int nsample);
+std::pair<torch::Tensor, torch::Tensor>
+ball_query_partial_dense(torch::Tensor x, torch::Tensor y, torch::Tensor batch_x,
+                         torch::Tensor batch_y, const float radius, const int nsample);
 
-at::Tensor degree(at::Tensor row, int64_t num_nodes);
+torch::Tensor degree(torch::Tensor row, int64_t num_nodes);

--- a/cuda/include/interpolate.h
+++ b/cuda/include/interpolate.h
@@ -3,7 +3,16 @@
 #include <torch/extension.h>
 #include <vector>
 
-std::vector<at::Tensor> three_nn(at::Tensor unknowns, at::Tensor knows);
-at::Tensor three_interpolate(at::Tensor points, at::Tensor idx, at::Tensor weight);
-at::Tensor three_interpolate_grad(at::Tensor grad_out, at::Tensor idx, at::Tensor weight,
+
+
+
+std::vector<torch::Tensor> three_nn(torch::Tensor unknowns, torch::Tensor knows);
+torch::Tensor three_interpolate(torch::Tensor points, torch::Tensor idx, torch::Tensor weight);
+torch::Tensor three_interpolate_grad(torch::Tensor grad_out, torch::Tensor idx, torch::Tensor weight,
                                   const int m);
+
+std::vector<torch::Tensor> three_nn_kernel_wrapper(torch::Tensor unknown, torch::Tensor known);
+torch::Tensor three_interpolate_kernel_wrapper(torch::Tensor points, torch::Tensor idx,
+                                               torch::Tensor weight);
+torch::Tensor three_interpolate_grad_kernel_wrapper(torch::Tensor grad_out, torch::Tensor idx,
+                                                    torch::Tensor weight, const int m);

--- a/cuda/include/sampling.h
+++ b/cuda/include/sampling.h
@@ -1,4 +1,4 @@
 #pragma once
 #include <torch/extension.h>
 
-at::Tensor furthest_point_sampling(at::Tensor points, const int nsamples);
+torch::Tensor furthest_point_sampling(torch::Tensor points, const int nsamples);

--- a/cuda/src/ball_query.cpp
+++ b/cuda/src/ball_query.cpp
@@ -1,19 +1,18 @@
 #include "ball_query.h"
 #include "compat.h"
 #include "utils.h"
+#include <torch/extension.h>
 
-void query_ball_point_kernel_dense_wrapper(int b, int n, int m, float radius, int nsample,
-                                           const float* new_xyz, const float* xyz, int64_t* idx,
-                                           float* dist_out);
+std::pair<torch::Tensor, torch::Tensor> query_ball_point_kernel_dense_wrapper(float radius,
+                                                                              int nsample,
+                                                                              torch::Tensor new_xyz,
+                                                                              torch::Tensor xyz);
+std::pair<torch::Tensor, torch::Tensor>
+query_ball_point_kernel_partial_wrapper(float radius, int nsample, torch::Tensor x, torch::Tensor y,
+                                        torch::Tensor batch_x, torch::Tensor batch_y);
 
-void query_ball_point_kernel_partial_wrapper(int64_t batch_size, int size_x, int size_y,
-                                             float radius, int nsample, const float* x,
-                                             const float* y, const int64_t* batch_x,
-                                             const int64_t* batch_y, int64_t* idx_out,
-                                             float* dist_out);
-
-std::pair<at::Tensor, at::Tensor> ball_query_dense(at::Tensor new_xyz, at::Tensor xyz,
-                                                   const float radius, const int nsample)
+std::pair<torch::Tensor, torch::Tensor> ball_query_dense(torch::Tensor new_xyz, torch::Tensor xyz,
+                                                         const float radius, const int nsample)
 {
     CHECK_CONTIGUOUS(new_xyz);
     CHECK_CONTIGUOUS(xyz);
@@ -23,28 +22,13 @@ std::pair<at::Tensor, at::Tensor> ball_query_dense(at::Tensor new_xyz, at::Tenso
     CHECK_CUDA(xyz);
     CHECK_CUDA(new_xyz);
 
-    at::Tensor idx = torch::zeros({new_xyz.size(0), new_xyz.size(1), nsample},
-                                  at::device(new_xyz.device()).dtype(at::ScalarType::Long));
-    at::Tensor dist = torch::full({new_xyz.size(0), new_xyz.size(1), nsample}, -1,
-                                  at::device(new_xyz.device()).dtype(at::ScalarType::Float));
-
-    query_ball_point_kernel_dense_wrapper(xyz.size(0), xyz.size(1), new_xyz.size(1), radius,
-                                          nsample, new_xyz.DATA_PTR<float>(), xyz.DATA_PTR<float>(),
-                                          idx.DATA_PTR<int64_t>(), dist.DATA_PTR<float>());
-
-    return std::make_pair(idx, dist);
+    return query_ball_point_kernel_dense_wrapper(radius, nsample, new_xyz, xyz);
 }
 
-at::Tensor degree(at::Tensor row, int64_t num_nodes)
-{
-    auto zero = at::zeros(num_nodes, row.options());
-    auto one = at::ones(row.size(0), row.options());
-    return zero.scatter_add_(0, row, one);
-}
 
-std::pair<at::Tensor, at::Tensor> ball_query_partial_dense(at::Tensor x, at::Tensor y,
-                                                           at::Tensor batch_x, at::Tensor batch_y,
-                                                           const float radius, const int nsample)
+std::pair<torch::Tensor, torch::Tensor>
+ball_query_partial_dense(torch::Tensor x, torch::Tensor y, torch::Tensor batch_x,
+                         torch::Tensor batch_y, const float radius, const int nsample)
 {
     CHECK_CONTIGUOUS(x);
     CHECK_CONTIGUOUS(y);
@@ -55,27 +39,5 @@ std::pair<at::Tensor, at::Tensor> ball_query_partial_dense(at::Tensor x, at::Ten
     CHECK_CUDA(batch_x);
     CHECK_CUDA(batch_y);
 
-    at::Tensor idx =
-        torch::full({y.size(0), nsample}, -1, at::device(y.device()).dtype(at::ScalarType::Long));
-
-    at::Tensor dist =
-        torch::full({y.size(0), nsample}, -1, at::device(y.device()).dtype(at::ScalarType::Float));
-
-    cudaSetDevice(x.get_device());
-    auto batch_sizes = (int64_t*)malloc(sizeof(int64_t));
-    cudaMemcpy(batch_sizes, batch_x[-1].DATA_PTR<int64_t>(), sizeof(int64_t),
-               cudaMemcpyDeviceToHost);
-    auto batch_size = batch_sizes[0] + 1;
-
-    batch_x = degree(batch_x, batch_size);
-    batch_x = at::cat({at::zeros(1, batch_x.options()), batch_x.cumsum(0)}, 0);
-    batch_y = degree(batch_y, batch_size);
-    batch_y = at::cat({at::zeros(1, batch_y.options()), batch_y.cumsum(0)}, 0);
-
-    query_ball_point_kernel_partial_wrapper(
-        batch_size, x.size(0), y.size(0), radius, nsample, x.DATA_PTR<float>(), y.DATA_PTR<float>(),
-        batch_x.DATA_PTR<int64_t>(), batch_y.DATA_PTR<int64_t>(), idx.DATA_PTR<int64_t>(),
-        dist.DATA_PTR<float>());
-
-    return std::make_pair(idx, dist);
+    return query_ball_point_kernel_partial_wrapper(radius, nsample, x, y, batch_x, batch_y);
 }

--- a/cuda/src/ball_query_gpu.cu
+++ b/cuda/src/ball_query_gpu.cu
@@ -3,14 +3,15 @@
 #include <stdlib.h>
 
 #include "cuda_utils.h"
-
+#include <torch/extension.h>
 // input: new_xyz(b, m, 3) xyz(b, n, 3)
 // output: idx(b, m, nsample)
+template <typename scalar_t>
 __global__ void query_ball_point_kernel_dense(int b, int n, int m, float radius, int nsample,
-                                              const float* __restrict__ new_xyz,
-                                              const float* __restrict__ xyz,
+                                              const scalar_t* __restrict__ new_xyz,
+                                              const scalar_t* __restrict__ xyz,
                                               int64_t* __restrict__ idx_out,
-                                              float* __restrict__ dist_out)
+                                              scalar_t* __restrict__ dist_out)
 {
     int batch_index = blockIdx.x;
     xyz += batch_index * n * 3;
@@ -24,15 +25,15 @@ __global__ void query_ball_point_kernel_dense(int b, int n, int m, float radius,
     float radius2 = radius * radius;
     for (int j = index; j < m; j += stride)
     {
-        float new_x = new_xyz[j * 3 + 0];
-        float new_y = new_xyz[j * 3 + 1];
-        float new_z = new_xyz[j * 3 + 2];
+        scalar_t new_x = new_xyz[j * 3 + 0];
+        scalar_t new_y = new_xyz[j * 3 + 1];
+        scalar_t new_z = new_xyz[j * 3 + 2];
         for (int k = 0, cnt = 0; k < n && cnt < nsample; ++k)
         {
-            float x = xyz[k * 3 + 0];
-            float y = xyz[k * 3 + 1];
-            float z = xyz[k * 3 + 2];
-            float d2 =
+            scalar_t x = xyz[k * 3 + 0];
+            scalar_t y = xyz[k * 3 + 1];
+            scalar_t z = xyz[k * 3 + 2];
+            scalar_t d2 =
                 (new_x - x) * (new_x - x) + (new_y - y) * (new_y - y) + (new_z - z) * (new_z - z);
             if (d2 < radius2)
             {
@@ -51,13 +52,14 @@ __global__ void query_ball_point_kernel_dense(int b, int n, int m, float radius,
     }
 }
 
+template <typename scalar_t>
 __global__ void query_ball_point_kernel_partial_dense(int size_x, int size_y, float radius,
-                                                      int nsample, const float* __restrict__ x,
-                                                      const float* __restrict__ y,
+                                                      int nsample, const scalar_t* __restrict__ x,
+                                                      const scalar_t* __restrict__ y,
                                                       const int64_t* __restrict__ batch_x,
                                                       const int64_t* __restrict__ batch_y,
                                                       int64_t* __restrict__ idx_out,
-                                                      float* __restrict__ dist_out)
+                                                      scalar_t* __restrict__ dist_out)
 {
     // taken from
     // https://github.com/rusty1s/pytorch_cluster/blob/master/cuda/radius_kernel.cu
@@ -75,7 +77,7 @@ __global__ void query_ball_point_kernel_partial_dense(int size_x, int size_y, fl
         int64_t count = 0;
         for (ptrdiff_t n_x = start_idx_x; n_x < end_idx_x; n_x++)
         {
-            float dist = 0;
+            scalar_t dist = 0;
             for (ptrdiff_t d = 0; d < 3; d++)
             {
                 dist += (x[n_x * 3 + d] - y[n_y * 3 + d]) * (x[n_x * 3 + d] - y[n_y * 3 + d]);
@@ -94,25 +96,83 @@ __global__ void query_ball_point_kernel_partial_dense(int size_x, int size_y, fl
     }
 }
 
-void query_ball_point_kernel_dense_wrapper(int b, int n, int m, float radius, int nsample,
-                                           const float* new_xyz, const float* xyz, int64_t* idx,
-                                           float* dist_out)
+std::pair<torch::Tensor, torch::Tensor> query_ball_point_kernel_dense_wrapper(float radius,
+                                                                              int nsample,
+                                                                              torch::Tensor new_xyz,
+                                                                              torch::Tensor xyz)
 {
+    int b = xyz.size(0);
+    int n = xyz.size(1);
+    int m = new_xyz.size(1);
+    torch::Tensor idx =
+        torch::zeros({new_xyz.size(0), new_xyz.size(1), nsample}, torch::CUDA(torch::ScalarType::Long));
+    torch::Tensor dist = torch::full({new_xyz.size(0), new_xyz.size(1), nsample}, -1,
+                                     torch::CUDA(xyz.scalar_type()));
+
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    query_ball_point_kernel_dense<<<b, opt_n_threads(m), 0, stream>>>(b, n, m, radius, nsample,
-                                                                      new_xyz, xyz, idx, dist_out);
+    // query_ball_point_kernel_dense<<<b, opt_n_threads(m), 0, stream>>>(b, n, m, radius, nsample,
+    //                                                                   new_xyz, xyz, idx,
+    //                                                                   dist_out);
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        new_xyz.scalar_type(), "query_ball_point_kernel_dense_cuda",
+        (
+            [&]
+            {
+                query_ball_point_kernel_dense<scalar_t><<<b, opt_n_threads(m), 0, stream>>>(
+                    b, n, m, radius, nsample, new_xyz.data_ptr<scalar_t>(),
+                    xyz.data_ptr<scalar_t>(), idx.data_ptr<int64_t>(), dist.data_ptr<scalar_t>());
+            }));
 
     CUDA_CHECK_ERRORS();
+    return std::make_pair(idx, dist);
 }
 
-void query_ball_point_kernel_partial_wrapper(int64_t batch_size, int size_x, int size_y,
-                                             float radius, int nsample, const float* x,
-                                             const float* y, const int64_t* batch_x,
-                                             const int64_t* batch_y, int64_t* idx_out,
-                                             float* dist_out)
+torch::Tensor degree(torch::Tensor row, int64_t num_nodes)
 {
-    query_ball_point_kernel_partial_dense<<<batch_size, TOTAL_THREADS_SPARSE>>>(
-        size_x, size_y, radius, nsample, x, y, batch_x, batch_y, idx_out, dist_out);
+    auto zero = torch::zeros(num_nodes, row.options());
+    auto one = torch::ones(row.size(0), row.options());
+    return zero.scatter_add_(0, row, one);
+}
+
+std::pair<torch::Tensor, torch::Tensor>
+query_ball_point_kernel_partial_wrapper(float radius, int nsample, torch::Tensor x, torch::Tensor y,
+                                        torch::Tensor batch_x, torch::Tensor batch_y)
+{
+
+    int size_x = x.size(0);
+    int size_y = y.size(0);
+    torch::Tensor idx = torch::full({y.size(0), nsample}, -1, torch::CUDA(torch::ScalarType::Long));
+
+    torch::Tensor dist = torch::full({y.size(0), nsample}, -1, torch::CUDA(y.scalar_type()));
+
+    cudaSetDevice(x.get_device());
+    auto batch_sizes = (int64_t*)malloc(sizeof(int64_t));
+    cudaMemcpy(batch_sizes, batch_x[-1].data_ptr<int64_t>(), sizeof(int64_t),
+               cudaMemcpyDeviceToHost);
+    auto batch_size = batch_sizes[0] + 1;
+
+    batch_x = degree(batch_x, batch_size);
+    batch_x = torch::cat({torch::zeros(1, batch_x.options()), batch_x.cumsum(0)}, 0);
+    batch_y = degree(batch_y, batch_size);
+    batch_y = torch::cat({torch::zeros(1, batch_y.options()), batch_y.cumsum(0)}, 0);
+
+    // query_ball_point_kernel_partial_dense<<<batch_size, TOTAL_THREADS_SPARSE>>>(
+    //     size_x, size_y, radius, nsample, x, y, batch_x, batch_y, idx_out, dist_out);
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        x.scalar_type(), "query_ball_point_kernel_dense_cuda",
+        (
+            [&]
+            {
+                query_ball_point_kernel_partial_dense<scalar_t>
+                    <<<batch_size, TOTAL_THREADS_SPARSE>>>(
+                        size_x, size_y, radius, nsample, x.data_ptr<scalar_t>(),
+                        y.data_ptr<scalar_t>(), batch_x.data_ptr<int64_t>(),
+                        batch_y.data_ptr<int64_t>(), idx.data_ptr<int64_t>(),
+                        dist.data_ptr<scalar_t>());
+            }));
 
     CUDA_CHECK_ERRORS();
+
+    return std::make_pair(idx, dist);
 }

--- a/cuda/src/interpolate.cpp
+++ b/cuda/src/interpolate.cpp
@@ -2,14 +2,7 @@
 #include "compat.h"
 #include "utils.h"
 
-void three_nn_kernel_wrapper(int b, int n, int m, const float* unknown, const float* known,
-                             float* dist2, int* idx);
-void three_interpolate_kernel_wrapper(int b, int c, int m, int n, const float* points,
-                                      const int* idx, const float* weight, float* out);
-void three_interpolate_grad_kernel_wrapper(int b, int c, int n, int m, const float* grad_out,
-                                           const int* idx, const float* weight, float* grad_points);
-
-std::vector<at::Tensor> three_nn(at::Tensor unknowns, at::Tensor knows)
+std::vector<torch::Tensor> three_nn(torch::Tensor unknowns, torch::Tensor knows)
 {
     CHECK_CONTIGUOUS(unknowns);
     CHECK_CONTIGUOUS(knows);
@@ -19,19 +12,21 @@ std::vector<at::Tensor> three_nn(at::Tensor unknowns, at::Tensor knows)
     CHECK_CUDA(knows);
     CHECK_CUDA(unknowns);
 
-    at::Tensor idx = torch::zeros({unknowns.size(0), unknowns.size(1), 3},
-                                  at::device(unknowns.device()).dtype(at::ScalarType::Int));
-    at::Tensor dist2 = torch::zeros({unknowns.size(0), unknowns.size(1), 3},
-                                    at::device(unknowns.device()).dtype(at::ScalarType::Float));
+    // at::Tensor idx = torch::zeros({unknowns.size(0), unknowns.size(1), 3},
+    //                               at::device(unknowns.device()).dtype(at::ScalarType::Int));
+    // at::Tensor dist2 = torch::zeros({unknowns.size(0), unknowns.size(1), 3},
+    //                                 at::device(unknowns.device()).dtype(at::ScalarType::Float));
 
-    three_nn_kernel_wrapper(unknowns.size(0), unknowns.size(1), knows.size(1),
-                            unknowns.DATA_PTR<float>(), knows.DATA_PTR<float>(),
-                            dist2.DATA_PTR<float>(), idx.DATA_PTR<int>());
+    // three_nn_kernel_wrapper(unknowns.size(0), unknowns.size(1), knows.size(1),
+    //                         unknowns.DATA_PTR<float>(), knows.DATA_PTR<float>(),
+    //                         dist2.DATA_PTR<float>(), idx.DATA_PTR<int>());
 
-    return {dist2, idx};
+    return three_nn_kernel_wrapper(unknowns, knows);
+
+    // return {dist2, idx};
 }
 
-at::Tensor three_interpolate(at::Tensor points, at::Tensor idx, at::Tensor weight)
+torch::Tensor three_interpolate(torch::Tensor points, torch::Tensor idx, torch::Tensor weight)
 {
     CHECK_CONTIGUOUS(points);
     CHECK_CONTIGUOUS(idx);
@@ -43,17 +38,12 @@ at::Tensor three_interpolate(at::Tensor points, at::Tensor idx, at::Tensor weigh
     CHECK_CUDA(idx);
     CHECK_CUDA(weight);
 
-    at::Tensor output = torch::zeros({points.size(0), points.size(1), idx.size(1)},
-                                     at::device(points.device()).dtype(at::ScalarType::Float));
+    return three_interpolate_kernel_wrapper(points, idx, weight);
 
-    three_interpolate_kernel_wrapper(points.size(0), points.size(1), points.size(2), idx.size(1),
-                                     points.DATA_PTR<float>(), idx.DATA_PTR<int>(),
-                                     weight.DATA_PTR<float>(), output.DATA_PTR<float>());
-
-    return output;
+    // return output;
 }
-at::Tensor three_interpolate_grad(at::Tensor grad_out, at::Tensor idx, at::Tensor weight,
-                                  const int m)
+torch::Tensor three_interpolate_grad(torch::Tensor grad_out, torch::Tensor idx,
+                                     torch::Tensor weight, const int m)
 {
     CHECK_CONTIGUOUS(grad_out);
     CHECK_CONTIGUOUS(idx);
@@ -65,12 +55,7 @@ at::Tensor three_interpolate_grad(at::Tensor grad_out, at::Tensor idx, at::Tenso
     CHECK_CUDA(weight);
     CHECK_CUDA(grad_out);
 
-    at::Tensor output = torch::zeros({grad_out.size(0), grad_out.size(1), m},
-                                     at::device(grad_out.device()).dtype(at::ScalarType::Float));
+    return three_interpolate_grad_kernel_wrapper(grad_out, idx, weight, m);
 
-    three_interpolate_grad_kernel_wrapper(grad_out.size(0), grad_out.size(1), grad_out.size(2), m,
-                                          grad_out.DATA_PTR<float>(), idx.DATA_PTR<int>(),
-                                          weight.DATA_PTR<float>(), output.DATA_PTR<float>());
-
-    return output;
+    // return output;
 }

--- a/cuda/src/interpolate_gpu.cu
+++ b/cuda/src/interpolate_gpu.cu
@@ -1,13 +1,16 @@
+#include "cuda_utils.h"
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#include "cuda_utils.h"
+#include <torch/extension.h>
+#include <THC/THCAtomics.cuh>
+#include <vector>
 
 // input: unknown(b, n, 3) known(b, m, 3)
 // output: dist2(b, n, 3), idx(b, n, 3)
-__global__ void three_nn_kernel(int b, int n, int m, const float* __restrict__ unknown,
-                                const float* __restrict__ known, float* __restrict__ dist2,
+template <typename scalar_t>
+__global__ void three_nn_kernel(int b, int n, int m, const scalar_t* __restrict__ unknown,
+                                const scalar_t* __restrict__ known, scalar_t* __restrict__ dist2,
                                 int* __restrict__ idx)
 {
     int batch_index = blockIdx.x;
@@ -20,18 +23,38 @@ __global__ void three_nn_kernel(int b, int n, int m, const float* __restrict__ u
     int stride = blockDim.x;
     for (int j = index; j < n; j += stride)
     {
-        float ux = unknown[j * 3 + 0];
-        float uy = unknown[j * 3 + 1];
-        float uz = unknown[j * 3 + 2];
-
-        double best1 = 1e40, best2 = 1e40, best3 = 1e40;
+        scalar_t ux = unknown[j * 3 + 0];
+        scalar_t uy = unknown[j * 3 + 1];
+        scalar_t uz = unknown[j * 3 + 2];
+        scalar_t best1 = 65504, best2 = 65504, best3 = 65504;
+        if ((best1+1) > best1){
+            best1 = 1e20, best2 = 1e20, best3 = 1e20;
+        }
+        // switch (unknown.scalar_type())
+        // {
+        // case torch::ScalarType::Double:
+        //     best1 = 1e40, best2 = 1e40, best3 = 1e40;
+        //     break;
+        // case torch::ScalarType::Float:
+        //     best1 = 1e20, best2 = 1e20, best3 = 1e20;
+        //     break;
+        // case torch::ScalarType::Half:
+        //     best1 = 65504, best2 = 65504, best3 = 65504;
+        //     break;
+        // case torch::ScalarType::BFloat16:
+        //     best1 = 1e10, best2 = 1e20, best3 = 1e20;
+        //     break;
+        // default:
+        //     best1 = 1e20, best2 = 1e20, best3 = 1e20;
+        //     break;
+        // }
         int besti1 = 0, besti2 = 0, besti3 = 0;
         for (int k = 0; k < m; ++k)
         {
-            float x = known[k * 3 + 0];
-            float y = known[k * 3 + 1];
-            float z = known[k * 3 + 2];
-            float d = (ux - x) * (ux - x) + (uy - y) * (uy - y) + (uz - z) * (uz - z);
+            scalar_t x = known[k * 3 + 0];
+            scalar_t y = known[k * 3 + 1];
+            scalar_t z = known[k * 3 + 2];
+            scalar_t d = (ux - x) * (ux - x) + (uy - y) * (uy - y) + (uz - z) * (uz - z);
             if (d < best1)
             {
                 best3 = best2;
@@ -64,21 +87,37 @@ __global__ void three_nn_kernel(int b, int n, int m, const float* __restrict__ u
     }
 }
 
-void three_nn_kernel_wrapper(int b, int n, int m, const float* unknown, const float* known,
-                             float* dist2, int* idx)
+std::vector<torch::Tensor> three_nn_kernel_wrapper(torch::Tensor unknowns, torch::Tensor knows)
 {
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    three_nn_kernel<<<b, opt_n_threads(n), 0, stream>>>(b, n, m, unknown, known, dist2, idx);
+    int b = unknowns.size(0);
+    int n = unknowns.size(1);
+    int m = knows.size(1);
 
+    torch::Tensor idx = torch::zeros({b, n, 3}, torch::CUDA(torch::kInt));
+    torch::Tensor dist2 = torch::zeros({b, n, 3}, torch::CUDA(unknowns.scalar_type()));
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    // three_nn_kernel<<<b, opt_n_threads(n), 0, stream>>>(b, n, m, unknown, known, dist2, idx);
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        unknowns.scalar_type(), "three_nn_kernel_cuda",
+        (
+            [&]
+            {
+                three_nn_kernel<scalar_t><<<b, opt_n_threads(n), 0, stream>>>(
+                    b, n, m, unknowns.data_ptr<scalar_t>(), knows.data_ptr<scalar_t>(),
+                    dist2.data_ptr<scalar_t>(), idx.data_ptr<int>());
+            }));
     CUDA_CHECK_ERRORS();
+    return {dist2, idx};
 }
 
 // input: points(b, c, m), idx(b, n, 3), weight(b, n, 3)
 // output: out(b, c, n)
-__global__ void three_interpolate_kernel(int b, int c, int m, int n,
-                                         const float* __restrict__ points,
-                                         const int* __restrict__ idx,
-                                         const float* __restrict__ weight, float* __restrict__ out)
+template <typename scalar_t>
+__global__ void
+three_interpolate_kernel(int b, int c, int m, int n, const scalar_t* __restrict__ points,
+                         const int* __restrict__ idx, const scalar_t* __restrict__ weight,
+                         scalar_t* __restrict__ out)
 {
     int batch_index = blockIdx.x;
     points += batch_index * m * c;
@@ -94,9 +133,9 @@ __global__ void three_interpolate_kernel(int b, int c, int m, int n,
     {
         const int l = i / n;
         const int j = i % n;
-        float w1 = weight[j * 3 + 0];
-        float w2 = weight[j * 3 + 1];
-        float w3 = weight[j * 3 + 2];
+        scalar_t w1 = weight[j * 3 + 0];
+        scalar_t w2 = weight[j * 3 + 1];
+        scalar_t w3 = weight[j * 3 + 2];
 
         int i1 = idx[j * 3 + 0];
         int i2 = idx[j * 3 + 1];
@@ -106,24 +145,38 @@ __global__ void three_interpolate_kernel(int b, int c, int m, int n,
     }
 }
 
-void three_interpolate_kernel_wrapper(int b, int c, int m, int n, const float* points,
-                                      const int* idx, const float* weight, float* out)
+torch::Tensor three_interpolate_kernel_wrapper(torch::Tensor points, torch::Tensor idx,
+                                               torch::Tensor weight)
 {
+    int b = points.size(0);
+    int c = points.size(1);
+    int m = points.size(2);
+    int n = idx.size(1);
+
+    torch::Tensor out = torch::zeros({b, c, n}, torch::CUDA(points.scalar_type()));
+
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    three_interpolate_kernel<<<b, opt_block_config(n, c), 0, stream>>>(b, c, m, n, points, idx,
-                                                                       weight, out);
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        points.scalar_type(), "three_interpolate_kernel_cuda",
+        (
+            [&]
+            {
+                three_interpolate_kernel<scalar_t><<<b, opt_block_config(n, c), 0, stream>>>(
+                    b, c, m, n, points.data_ptr<scalar_t>(), idx.data_ptr<int>(),
+                    weight.data_ptr<scalar_t>(), out.data_ptr<scalar_t>());
+            }));
 
     CUDA_CHECK_ERRORS();
+    return out;
 }
 
 // input: grad_out(b, c, n), idx(b, n, 3), weight(b, n, 3)
 // output: grad_points(b, c, m)
-
-__global__ void three_interpolate_grad_kernel(int b, int c, int n, int m,
-                                              const float* __restrict__ grad_out,
-                                              const int* __restrict__ idx,
-                                              const float* __restrict__ weight,
-                                              float* __restrict__ grad_points)
+template <typename scalar_t>
+__global__ void
+three_interpolate_grad_kernel(int b, int c, int n, int m, const scalar_t* __restrict__ grad_out,
+                              const int* __restrict__ idx, const scalar_t* __restrict__ weight,
+                              scalar_t* __restrict__ grad_points)
 {
     int batch_index = blockIdx.x;
     grad_out += batch_index * n * c;
@@ -137,26 +190,46 @@ __global__ void three_interpolate_grad_kernel(int b, int c, int n, int m,
     {
         const int l = i / n;
         const int j = i % n;
-        float w1 = weight[j * 3 + 0];
-        float w2 = weight[j * 3 + 1];
-        float w3 = weight[j * 3 + 2];
+        scalar_t w1 = weight[j * 3 + 0];
+        scalar_t w2 = weight[j * 3 + 1];
+        scalar_t w3 = weight[j * 3 + 2];
 
         int i1 = idx[j * 3 + 0];
         int i2 = idx[j * 3 + 1];
         int i3 = idx[j * 3 + 2];
 
-        atomicAdd(grad_points + l * m + i1, grad_out[i] * w1);
-        atomicAdd(grad_points + l * m + i2, grad_out[i] * w2);
-        atomicAdd(grad_points + l * m + i3, grad_out[i] * w3);
+        gpuAtomicAdd(grad_points + l * m + i1, grad_out[i] * w1);
+        gpuAtomicAdd(grad_points + l * m + i2, grad_out[i] * w2);
+        gpuAtomicAdd(grad_points + l * m + i3, grad_out[i] * w3);
+
+        // atomicAdd(grad_points + l * m + i1, grad_out[i] * w1);
+        // atomicAdd(grad_points + l * m + i2, grad_out[i] * w2);
+        // atomicAdd(grad_points + l * m + i3, grad_out[i] * w3);
     }
 }
 
-void three_interpolate_grad_kernel_wrapper(int b, int c, int n, int m, const float* grad_out,
-                                           const int* idx, const float* weight, float* grad_points)
+torch::Tensor three_interpolate_grad_kernel_wrapper(torch::Tensor grad_out, torch::Tensor idx,
+                                                    torch::Tensor weight, const int m)
 {
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    three_interpolate_grad_kernel<<<b, opt_block_config(n, c), 0, stream>>>(
-        b, c, n, m, grad_out, idx, weight, grad_points);
+    int b = grad_out.size(0);
+    int c = grad_out.size(1);
+    int n = grad_out.size(2);
 
+    torch::Tensor grad_points = torch::zeros({b, c, m}, torch::CUDA(grad_out.scalar_type()));
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    // three_interpolate_grad_kernel<<<b, opt_block_config(n, c), 0, stream>>>(
+    //     b, c, n, m, grad_out, idx, weight, grad_points);
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        grad_out.scalar_type(), "three_interpolate_grad_kernel_cuda",
+        (
+            [&]
+            {
+                three_interpolate_grad_kernel<scalar_t><<<b, opt_block_config(n, c), 0, stream>>>(
+                    b, c, n, m, grad_out.data_ptr<scalar_t>(), idx.data_ptr<int>(),
+                    weight.data_ptr<scalar_t>(), grad_points.data_ptr<scalar_t>());
+            }));
     CUDA_CHECK_ERRORS();
+    return grad_points;
 }

--- a/cuda/src/sampling.cpp
+++ b/cuda/src/sampling.cpp
@@ -2,24 +2,16 @@
 #include "compat.h"
 #include "utils.h"
 
-void furthest_point_sampling_kernel_wrapper(int b, int n, int m, const float* dataset, float* temp,
-                                            int* idxs);
+torch::Tensor furthest_point_sampling_kernel_wrapper(torch::Tensor points, const int nsamples);
 
-at::Tensor furthest_point_sampling(at::Tensor points, const int nsamples)
+torch::Tensor furthest_point_sampling(torch::Tensor points, const int nsamples)
 {
     CHECK_CONTIGUOUS(points);
     CHECK_IS_FLOAT(points);
     CHECK_CUDA(points);
 
-    at::Tensor output = torch::zeros({points.size(0), nsamples},
-                                     at::device(points.device()).dtype(at::ScalarType::Int));
 
-    at::Tensor tmp = torch::full({points.size(0), points.size(1)}, 1e10,
-                                 at::device(points.device()).dtype(at::ScalarType::Float));
+    return furthest_point_sampling_kernel_wrapper(points, nsamples);
 
-    furthest_point_sampling_kernel_wrapper(points.size(0), points.size(1), nsamples,
-                                           points.DATA_PTR<float>(), tmp.DATA_PTR<float>(),
-                                           output.DATA_PTR<int>());
-
-    return output;
+    // return output;
 }

--- a/cuda/src/sampling_gpu.cu
+++ b/cuda/src/sampling_gpu.cu
@@ -1,11 +1,13 @@
+#include "cuda_utils.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <torch/extension.h>
 
-#include "cuda_utils.h"
-
-__device__ void __update(float* __restrict__ dists, int* __restrict__ dists_i, int idx1, int idx2)
+template <typename scalar_t>
+__device__ void __update(scalar_t* __restrict__ dists, int* __restrict__ dists_i, int idx1,
+                         int idx2)
 {
-    const float v1 = dists[idx1], v2 = dists[idx2];
+    const scalar_t v1 = dists[idx1], v2 = dists[idx2];
     const int i1 = dists_i[idx1], i2 = dists_i[idx2];
     dists[idx1] = max(v1, v2);
     dists_i[idx1] = v2 > v1 ? i2 : i1;
@@ -13,14 +15,14 @@ __device__ void __update(float* __restrict__ dists, int* __restrict__ dists_i, i
 
 // Input dataset: (b, n, 3), tmp: (b, n)
 // Ouput idxs (b, m)
-template <unsigned int block_size>
+template <typename scalar_t, unsigned int block_size>
 __global__ void furthest_point_sampling_kernel(int b, int n, int m,
-                                               const float* __restrict__ dataset,
-                                               float* __restrict__ temp, int* __restrict__ idxs)
+                                               const scalar_t* __restrict__ dataset,
+                                               scalar_t* __restrict__ temp, int* __restrict__ idxs)
 {
     if (m <= 0)
         return;
-    __shared__ float dists[block_size];
+    __shared__ scalar_t dists[block_size];
     __shared__ int dists_i[block_size];
 
     int batch_index = blockIdx.x;
@@ -36,26 +38,26 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         idxs[0] = old;
 
     __syncthreads();
-    for (int j = 1; j < m; j++)
+    for (int j = 0; j < m; j++)
     {
         int besti = 0;
-        float best = -1;
-        float x1 = dataset[old * 3 + 0];
-        float y1 = dataset[old * 3 + 1];
-        float z1 = dataset[old * 3 + 2];
+        scalar_t best = -1;
+        scalar_t x1 = dataset[old * 3 + 0];
+        scalar_t y1 = dataset[old * 3 + 1];
+        scalar_t z1 = dataset[old * 3 + 2];
         for (int k = tid; k < n; k += stride)
         {
-            float x2, y2, z2;
+            scalar_t x2, y2, z2;
             x2 = dataset[k * 3 + 0];
             y2 = dataset[k * 3 + 1];
             z2 = dataset[k * 3 + 2];
-            float mag = (x2 * x2) + (y2 * y2) + (z2 * z2);
+            scalar_t mag = (x2 * x2) + (y2 * y2) + (z2 * z2);
             if (mag <= 1e-3)
                 continue;
 
-            float d = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1) + (z2 - z1) * (z2 - z1);
+            scalar_t d = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1) + (z2 - z1) * (z2 - z1);
 
-            float d2 = min(d, temp[k]);
+            scalar_t d2 = min(d, temp[k]);
             temp[k] = d2;
             besti = d2 > best ? k : besti;
             best = d2 > best ? d2 : best;
@@ -68,7 +70,7 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         {
             if (tid < 256)
             {
-                __update(dists, dists_i, tid, tid + 256);
+                __update<scalar_t>(dists, dists_i, tid, tid + 256);
             }
             __syncthreads();
         }
@@ -76,7 +78,7 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         {
             if (tid < 128)
             {
-                __update(dists, dists_i, tid, tid + 128);
+                __update<scalar_t>(dists, dists_i, tid, tid + 128);
             }
             __syncthreads();
         }
@@ -84,7 +86,7 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         {
             if (tid < 64)
             {
-                __update(dists, dists_i, tid, tid + 64);
+                __update<scalar_t>(dists, dists_i, tid, tid + 64);
             }
             __syncthreads();
         }
@@ -92,7 +94,7 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         {
             if (tid < 32)
             {
-                __update(dists, dists_i, tid, tid + 32);
+                __update<scalar_t>(dists, dists_i, tid, tid + 32);
             }
             __syncthreads();
         }
@@ -100,7 +102,7 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         {
             if (tid < 16)
             {
-                __update(dists, dists_i, tid, tid + 16);
+                __update<scalar_t>(dists, dists_i, tid, tid + 16);
             }
             __syncthreads();
         }
@@ -108,7 +110,7 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         {
             if (tid < 8)
             {
-                __update(dists, dists_i, tid, tid + 8);
+                __update<scalar_t>(dists, dists_i, tid, tid + 8);
             }
             __syncthreads();
         }
@@ -116,7 +118,7 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         {
             if (tid < 4)
             {
-                __update(dists, dists_i, tid, tid + 4);
+                __update<scalar_t>(dists, dists_i, tid, tid + 4);
             }
             __syncthreads();
         }
@@ -124,7 +126,7 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         {
             if (tid < 2)
             {
-                __update(dists, dists_i, tid, tid + 2);
+                __update<scalar_t>(dists, dists_i, tid, tid + 2);
             }
             __syncthreads();
         }
@@ -132,7 +134,7 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
         {
             if (tid < 1)
             {
-                __update(dists, dists_i, tid, tid + 1);
+                __update<scalar_t>(dists, dists_i, tid, tid + 1);
             }
             __syncthreads();
         }
@@ -143,59 +145,204 @@ __global__ void furthest_point_sampling_kernel(int b, int n, int m,
     }
 }
 
-void furthest_point_sampling_kernel_wrapper(int b, int n, int m, const float* dataset, float* temp,
-                                            int* idxs)
+torch::Tensor furthest_point_sampling_kernel_wrapper(torch::Tensor points, const int nsamples)
 {
-    unsigned int n_threads = opt_n_threads(n);
+
+    int b = points.size(0);
+    int n = points.size(1);
+    int m = nsamples;
+    torch::Tensor idxs =
+        torch::zeros({points.size(0), nsamples}, torch::CUDA(torch::ScalarType::Int));
+
+    float init_num = 0;
+    switch (points.scalar_type())
+    {
+    case torch::ScalarType::Half:
+        init_num = 65504;
+        break;
+    default:
+        init_num = 1e10;
+        break;
+    }
+
+    torch::Tensor temp =
+        torch::full({points.size(0), points.size(1)}, init_num, torch::CUDA(points.scalar_type()));
+    const unsigned int n_threads = opt_n_threads(n);
 
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    // switch (n_threads)
+    // {
+    // case 512:
+    //     furthest_point_sampling_kernel<512>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // case 256:
+    //     furthest_point_sampling_kernel<256>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // case 128:
+    //     furthest_point_sampling_kernel<128>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // case 64:
+    //     furthest_point_sampling_kernel<64>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // case 32:
+    //     furthest_point_sampling_kernel<32>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // case 16:
+    //     furthest_point_sampling_kernel<16>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // case 8:
+    //     furthest_point_sampling_kernel<8>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // case 4:
+    //     furthest_point_sampling_kernel<4>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // case 2:
+    //     furthest_point_sampling_kernel<2>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // case 1:
+    //     furthest_point_sampling_kernel<1>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    //     break;
+    // default:
+    //     furthest_point_sampling_kernel<512>
+    //         <<<b, n_threads, 0, stream>>>(b, n, m, points, temp, idxs);
+    // }
 
     switch (n_threads)
     {
     case 512:
-        furthest_point_sampling_kernel<512>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 512><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     case 256:
-        furthest_point_sampling_kernel<256>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 256><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     case 128:
-        furthest_point_sampling_kernel<128>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 128><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     case 64:
-        furthest_point_sampling_kernel<64>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 64><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     case 32:
-        furthest_point_sampling_kernel<32>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 32><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     case 16:
-        furthest_point_sampling_kernel<16>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 16><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     case 8:
-        furthest_point_sampling_kernel<8>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 8><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     case 4:
-        furthest_point_sampling_kernel<4>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 4><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     case 2:
-        furthest_point_sampling_kernel<2>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 2><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     case 1:
-        furthest_point_sampling_kernel<1>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 1><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
         break;
     default:
-        furthest_point_sampling_kernel<512>
-            <<<b, n_threads, 0, stream>>>(b, n, m, dataset, temp, idxs);
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            points.scalar_type(), "furthest_point_sampling_kernel_cuda",
+            (
+                [&]
+                {
+                    furthest_point_sampling_kernel<scalar_t, 512><<<b, n_threads, 0, stream>>>(
+                        b, n, m, points.data_ptr<scalar_t>(), temp.data_ptr<scalar_t>(),
+                        idxs.data_ptr<int>());
+                }));
+        break;
     }
 
     CUDA_CHECK_ERRORS();
+    return idxs;
 }

--- a/test/test_chamfer_dist.py
+++ b/test/test_chamfer_dist.py
@@ -6,14 +6,14 @@ import unittest
 
 from torch.autograd import gradcheck
 
-from . import run_if_cuda
+
 
 
 ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.insert(0, ROOT)
 
 from torch_points_kernels.chamfer_dist import ChamferFunction, chamfer_dist
-
+from test import run_if_cuda
 
 class TestChamferDistance(unittest.TestCase):
     @run_if_cuda

--- a/test/test_fps.py
+++ b/test/test_fps.py
@@ -3,10 +3,14 @@ import torch
 import os
 import sys
 
+
+
 ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.insert(0, ROOT)
 
 from torch_points_kernels.points_cpu import fps
+from torch_points_kernels import furthest_point_sample
+from test import run_if_cuda
 
 
 class TestFps(unittest.TestCase):
@@ -20,6 +24,15 @@ class TestFps(unittest.TestCase):
         idx = fps(points, 2, True)
         self.assertNotEqual(idx[0][0], 0)
 
+    @run_if_cuda
+    def test_gpu(self):
+        points = torch.randn([16, 100, 3]).cuda()
+        nsamples = 2
+        idx = furthest_point_sample(points,nsamples)
+        idx_cpu = furthest_point_sample(points.cpu(),nsamples)
+        sorted_idx, _ = torch.sort(idx.cpu())
+        sorted_idx_cpu, _ = torch.sort(idx_cpu)
+        torch.testing.assert_allclose(sorted_idx,sorted_idx_cpu)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_interpolate.py
+++ b/test/test_interpolate.py
@@ -2,9 +2,11 @@ import unittest
 import torch
 from torch.autograd import gradcheck
 from torch_points_kernels import three_interpolate, three_nn
-
-from . import run_if_cuda
-
+import sys 
+import os
+ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+sys.path.insert(0, ROOT)
+from test import run_if_cuda
 
 class TestInterpolate(unittest.TestCase):
     @run_if_cuda

--- a/torch_points_kernels/cubic_feature_sampling.py
+++ b/torch_points_kernels/cubic_feature_sampling.py
@@ -1,11 +1,12 @@
 import torch
-
+from torch.cuda.amp import custom_bwd,custom_fwd
 if torch.cuda.is_available():
     import torch_points_kernels.points_cuda as tpcuda
 
 
 class CubicFeatureSamplingFunction(torch.autograd.Function):
     @staticmethod
+    @custom_fwd(cast_inputs=torch.half)
     def forward(ctx, ptcloud, cubic_features, neighborhood_size=1):
         scale = cubic_features.size(2)
         if not torch.cuda.is_available():
@@ -18,6 +19,7 @@ class CubicFeatureSamplingFunction(torch.autograd.Function):
         return point_features
 
     @staticmethod
+    @custom_bwd
     def backward(ctx, grad_point_features):
         scale, neighborhood_size, grid_pt_indexes = ctx.saved_tensors
         scale = int(scale.item())

--- a/torch_points_kernels/gridding.py
+++ b/torch_points_kernels/gridding.py
@@ -1,4 +1,5 @@
 import torch
+from torch.cuda.amp import custom_bwd,custom_fwd
 
 if torch.cuda.is_available():
     import torch_points_kernels.points_cuda as tpcuda
@@ -6,6 +7,7 @@ if torch.cuda.is_available():
 
 class GriddingFunction(torch.autograd.Function):
     @staticmethod
+    @custom_fwd(cast_inputs=torch.half)
     def forward(ctx, ptcloud, scale):
         if not torch.cuda.is_available():
             raise NotImplementedError("CPU version is not available for Chamfer Distance")
@@ -21,6 +23,7 @@ class GriddingFunction(torch.autograd.Function):
         return grid
 
     @staticmethod
+    @custom_bwd
     def backward(ctx, grad_grid):
         grid_pt_weights, grid_pt_indexes = ctx.saved_tensors
         grad_ptcloud = tpcuda.gridding_grad(grid_pt_weights, grid_pt_indexes, grad_grid)


### PR DESCRIPTION
Hi, 

Thank you for this great library and torch-points3d.

I made some modifications to support mixed-precision training. 

The major changes are as follows:
- template kernel function in interpolate_gpu.cu  sampling_gpu.cu and ball_query_gpu.cu.
- Change ```AT_DISPATCH_FLOATING_TYPES``` to ```AT_DISPATCH_FLOATING_TYPES_AND_HALF```;
- Change ```atomicAdd``` to ```gpuAtomicAdd``` (in [pytorch THCAtomics.cuh](https://github.com/pytorch/pytorch/blob/master/aten/src/THC/THCAtomics.cuh));
- Add ```custom_fwd``` and  ```custom_bwd``` in ```torch.autograd.Function``` to allow [ ```autocast```](https://pytorch.org/docs/stable/notes/amp_examples.html#autocast-and-custom-autograd-functions);
- fixed bug of sampling_gpu which the first element of idx output is always 0; (But I found that the output of GPU version and CPU version are not the same. I haven't fixed this.)

The modified version passed the tests in the test folder. I didn't see affection on full-precision training.  And I tried to train the PointNet2 model in the torch-point3d library in a mixed-precision style, it works. 
